### PR TITLE
Update acceptance test to embed HCL2 configs

### DIFF
--- a/builder/upcloud/builder_acc_test.go
+++ b/builder/upcloud/builder_acc_test.go
@@ -78,13 +78,13 @@ func TestBuilderAcc_networking(t *testing.T) {
 
 // pkr.hcl
 
-//go:embed test-fixtures/json/basic.json
+//go:embed test-fixtures/hcl2/basic.pkr.hcl
 var testBuildBasicHcl string
 
-//go:embed test-fixtures/json/storage-uuid.json
+//go:embed test-fixtures/hcl2/storage-uuid.pkr.hcl
 var testBuilderStorageUuidHcl string
 
-//go:embed test-fixtures/json/storage-name.json
+//go:embed test-fixtures/hcl2/storage-name.pkr.hcl
 var testBuilderStorageNameHcl string
 
 func TestBuilderAcc_default_hcl(t *testing.T) {


### PR DESCRIPTION
Results after change
```
2021/09/27 18:32:41 ui:
plugin process exited
Cleaning up created templates: 019e5305-e2a2-4b91-ae74-696c9c38f2b5
--- PASS: TestBuilderAcc_default_hcl (120.60s)
PASS
ok      github.com/UpCloudLtd/packer-plugin-upcloud/builder/upcloud 120.747s
?       github.com/UpCloudLtd/packer-plugin-upcloud/internal    [no test files]
```