### PR TITLE
fix(build): Windows builds has no .exe extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ lint:
 	golint .
 
 build:
-	go build -v -o $(BINARY)
+	go build -v
 
 install: build
 	@mkdir -p ~/.packer.d/plugins


### PR DESCRIPTION
Windows builds are failing with error
`Ignoring plugin match D:\a\packer-plugin-upcloud\packer-plugin-upcloud\builder\upcloud\packer-plugin-upcloud, no exe extension`

This was caused by latest change in `make build` 