### PR TITLE
fix(builder): refactor network_interfaces handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 ### Added
--  add new template name param 
+- add new template name param 
+- new `default` IP address flag to select used interface/IP during build
+- new `wait_boot` flag adds ability to wait N time for server to boot up and start all services
+- add `none` communicator support
+- support for IPv6 interfaces
 
 ### Changed
 - update README file
 - update acceptance test to embed HCL2 configs 
+- drop public IPv4 interface requirement
 
 ### Fixed
 - fix network interface config

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test:
 
 test_integration: build
 	cp $(BINARY) builder/upcloud/
-	PACKER_ACC=1 go test -count 1 -v ./...  -timeout=120m
+	PACKER_ACC=1 go test -count 1 -v $(TESTARGS) ./...  -timeout=120m
 
 lint:
 	go vet .
@@ -49,6 +49,7 @@ generate: fmt install-packer-sdc
 	$(PACKER_SDC_RENDER_DOCS)
 
 fmt:
+	packer fmt builder/upcloud/test-fixtures/hcl2
 	packer fmt example/
 	packer fmt -recursive docs-partials/
 

--- a/builder/upcloud/builder.go
+++ b/builder/upcloud/builder.go
@@ -68,11 +68,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			Config:        &b.config,
 			GeneratedData: generatedData,
 		},
-		&communicator.StepConnect{
-			Config:    &b.config.Comm,
-			Host:      sshHostCallback,
-			SSHConfig: b.config.Comm.SSHConfigFunc(),
-		},
+		b.communicatorStep(),
 		&commonsteps.StepProvision{},
 		&commonsteps.StepCleanupTempKeys{
 			Comm: &b.config.Comm,
@@ -110,4 +106,22 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 	}
 
 	return artifact, nil
+}
+
+// CommunicatorStep returns step based on communicator type
+// We currently support only SSH communicator but 'none' type
+// can also be used for e.g. testing purposes
+func (b *Builder) communicatorStep() multistep.Step {
+	switch b.config.Comm.Type {
+	case "none":
+		return &communicator.StepConnect{
+			Config: &b.config.Comm,
+		}
+	default:
+		return &communicator.StepConnect{
+			Config:    &b.config.Comm,
+			Host:      sshHostCallback,
+			SSHConfig: b.config.Comm.SSHConfigFunc(),
+		}
+	}
 }

--- a/builder/upcloud/config.hcl2spec.go
+++ b/builder/upcloud/config.hcl2spec.go
@@ -76,6 +76,7 @@ type FlatConfig struct {
 	TemplateName              *string                `mapstructure:"template_name" cty:"template_name" hcl:"template_name"`
 	StorageSize               *int                   `mapstructure:"storage_size" cty:"storage_size" hcl:"storage_size"`
 	Timeout                   *string                `mapstructure:"state_timeout_duration" cty:"state_timeout_duration" hcl:"state_timeout_duration"`
+	BootWait                  *string                `mapstructure:"boot_wait" cty:"boot_wait" hcl:"boot_wait"`
 	CloneZones                []string               `mapstructure:"clone_zones" cty:"clone_zones" hcl:"clone_zones"`
 	NetworkInterfaces         []FlatNetworkInterface `mapstructure:"network_interfaces" cty:"network_interfaces" hcl:"network_interfaces"`
 	SSHPrivateKeyPath         *string                `mapstructure:"ssh_private_key_path" cty:"ssh_private_key_path" hcl:"ssh_private_key_path"`
@@ -160,6 +161,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"template_name":                &hcldec.AttrSpec{Name: "template_name", Type: cty.String, Required: false},
 		"storage_size":                 &hcldec.AttrSpec{Name: "storage_size", Type: cty.Number, Required: false},
 		"state_timeout_duration":       &hcldec.AttrSpec{Name: "state_timeout_duration", Type: cty.String, Required: false},
+		"boot_wait":                    &hcldec.AttrSpec{Name: "boot_wait", Type: cty.String, Required: false},
 		"clone_zones":                  &hcldec.AttrSpec{Name: "clone_zones", Type: cty.List(cty.String), Required: false},
 		"network_interfaces":           &hcldec.BlockListSpec{TypeName: "network_interfaces", Nested: hcldec.ObjectSpec((*FlatNetworkInterface)(nil).HCL2Spec())},
 		"ssh_private_key_path":         &hcldec.AttrSpec{Name: "ssh_private_key_path", Type: cty.String, Required: false},
@@ -171,6 +173,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 // FlatIPAddress is an auto-generated flat version of IPAddress.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatIPAddress struct {
+	Default *bool   `mapstructure:"default" cty:"default" hcl:"default"`
 	Family  *string `mapstructure:"family" cty:"family" hcl:"family"`
 	Address *string `mapstructure:"address,omitempty" cty:"address" hcl:"address"`
 }
@@ -187,6 +190,7 @@ func (*IPAddress) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spe
 // The decoded values from this spec will then be applied to a FlatIPAddress.
 func (*FlatIPAddress) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
+		"default": &hcldec.AttrSpec{Name: "default", Type: cty.Bool, Required: false},
 		"family":  &hcldec.AttrSpec{Name: "family", Type: cty.String, Required: false},
 		"address": &hcldec.AttrSpec{Name: "address", Type: cty.String, Required: false},
 	}
@@ -197,7 +201,7 @@ func (*FlatIPAddress) HCL2Spec() map[string]hcldec.Spec {
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatNetworkInterface struct {
 	IPAddresses []FlatIPAddress `mapstructure:"ip_addresses" cty:"ip_addresses" hcl:"ip_addresses"`
-	Type        *string         `mapstructure:"type" cty:"type" hcl:"type"`
+	Type        *InterfaceType  `mapstructure:"type" cty:"type" hcl:"type"`
 	Network     *string         `mapstructure:"network,omitempty" cty:"network" hcl:"network"`
 }
 

--- a/builder/upcloud/test-fixtures/hcl2/network_interfaces.pkr.hcl
+++ b/builder/upcloud/test-fixtures/hcl2/network_interfaces.pkr.hcl
@@ -1,0 +1,27 @@
+source "upcloud" "network_interfaces" {
+  storage_name = "Debian GNU/Linux 11 (Bullseye)"
+  storage_size = 10
+  zone         = "nl-ams1"
+
+  network_interfaces {
+    ip_addresses {
+      family = "IPv4"
+    }
+    type = "public"
+  }
+
+  network_interfaces {
+    ip_addresses {
+      default = true
+      family  = "IPv4"
+    }
+    type = "utility"
+  }
+
+  communicator = "none"
+  boot_wait    = "1m"
+}
+
+build {
+  sources = ["source.upcloud.network_interfaces"]
+}

--- a/builder/upcloud/utils_test.go
+++ b/builder/upcloud/utils_test.go
@@ -1,0 +1,167 @@
+package upcloud
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/UpCloudLtd/upcloud-go-api/upcloud"
+	"github.com/UpCloudLtd/upcloud-go-api/upcloud/request"
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+)
+
+func TestFindIPAddressByType(t *testing.T) {
+	want := "127.0.0.1"
+	got, err := findIPAddressByType(upcloud.IPAddressSlice{
+		upcloud.IPAddress{
+			Access:  upcloud.IPAddressAccessPrivate,
+			Address: want,
+			Family:  "IPv4",
+		},
+		upcloud.IPAddress{
+			Access:  upcloud.IPAddressAccessPrivate,
+			Address: "127.0.0.2",
+			Family:  "IPv4",
+		},
+	}, InterfaceTypePrivate)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Address != want {
+		t.Errorf("findIPAddressByType failed want %s got %s", want, got.Address)
+	}
+
+	got, err = findIPAddressByType(upcloud.IPAddressSlice{
+		upcloud.IPAddress{
+			Access:  upcloud.IPAddressAccessPublic,
+			Address: want,
+			Family:  "IPv4",
+		},
+		upcloud.IPAddress{
+			Access:  upcloud.IPAddressAccessPublic,
+			Address: "::1/128",
+			Family:  "IPv6",
+		},
+	}, InterfaceTypePublic)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Address != want {
+		t.Errorf("findIPAddressByType failed want %s got %s", want, got.Address)
+	}
+
+	got, err = findIPAddressByType(upcloud.IPAddressSlice{
+		upcloud.IPAddress{
+			Access:  upcloud.IPAddressAccessPublic,
+			Address: want,
+			Family:  "IPv4",
+		},
+		upcloud.IPAddress{
+			Access:  upcloud.IPAddressAccessPublic,
+			Address: "::1/128",
+			Family:  "IPv6",
+		},
+	}, InterfaceTypePrivate)
+
+	if err == nil {
+		t.Errorf("findIPAddressByType failed got %s instead of error", got.Address)
+	}
+}
+
+func TestSSHHostCallback(t *testing.T) {
+	stateIPv6 := multistep.BasicStateBag{}
+	stateIPv6.Put("server_ip_address", &IPAddress{
+		Default: false,
+		Family:  "IPv6",
+		Address: "IPv6_address",
+	})
+	want := "[IPv6_address]"
+	got, err := sshHostCallback(&stateIPv6)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("IPv6 sshHostCallback failed want %s got %s", want, got)
+	}
+	stateIPv4 := multistep.BasicStateBag{}
+	stateIPv4.Put("server_ip_address", &IPAddress{
+		Default: false,
+		Family:  "IPv4",
+		Address: "IPv4_address",
+	})
+	want = "IPv4_address"
+	got, err = sshHostCallback(&stateIPv4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("IPv4 sshHostCallback failed want %s got %s", want, got)
+	}
+}
+
+func TestConvertNetworkTypes(t *testing.T) {
+	want := []request.CreateServerInterface{
+		{
+			IPAddresses: []request.CreateServerIPAddress{
+				{
+					Family:  "IPv4",
+					Address: "127.0.0.3",
+				},
+			},
+			Type:    upcloud.NetworkTypeUtility,
+			Network: "",
+		},
+		{
+			IPAddresses: []request.CreateServerIPAddress{
+				{
+					Family:  "IPv4",
+					Address: "127.0.0.2",
+				},
+			},
+			Type:    upcloud.NetworkTypePrivate,
+			Network: "",
+		},
+		{
+			IPAddresses: []request.CreateServerIPAddress{
+				{
+					Family:  "IPv6",
+					Address: "127.0.0.1",
+				},
+			},
+			Type:    upcloud.NetworkTypePublic,
+			Network: "",
+		},
+	}
+	got := convertNetworkTypes([]NetworkInterface{
+		{
+			IPAddresses: []IPAddress{{
+				Family:  "IPv4",
+				Address: "127.0.0.3",
+			}},
+			Type:    InterfaceTypeUtility,
+			Network: "",
+		},
+		{
+			IPAddresses: []IPAddress{{
+				Family:  "IPv4",
+				Address: "127.0.0.2",
+			}},
+			Type:    InterfaceTypePrivate,
+			Network: "",
+		},
+		{
+			IPAddresses: []IPAddress{{
+				Family:  "IPv6",
+				Address: "127.0.0.1",
+			}},
+			Type:    InterfaceTypePublic,
+			Network: "",
+		},
+	})
+	for i := range got {
+		if !reflect.DeepEqual(want[i], got[i]) {
+			t.Fatalf("convertNetworkTypes failed IP want %+v got %+v", want, got)
+		}
+	}
+}

--- a/docs-partials/builder/upcloud/Config-not-required.mdx
+++ b/docs-partials/builder/upcloud/Config-not-required.mdx
@@ -18,6 +18,8 @@
 
 - `state_timeout_duration` (duration string | ex: "1h5m2s") - The amount of time to wait for resource state changes. Defaults to `5m`.
 
+- `boot_wait` (duration string | ex: "1h5m2s") - The amount of time to wait after booting the server. Defaults to '0s'
+
 - `clone_zones` ([]string) - The array of extra zones (locations) where created templates should be cloned.
   Note that default `state_timeout_duration` is not enough for cloning, better to increase a value depending on storage size.
 

--- a/docs-partials/builder/upcloud/IPAddress-not-required.mdx
+++ b/docs-partials/builder/upcloud/IPAddress-not-required.mdx
@@ -1,7 +1,9 @@
 <!-- Code generated from the comments of the IPAddress struct in builder/upcloud/config.go; DO NOT EDIT MANUALLY -->
 
-- `family` (string) - Family
+- `default` (bool) - Default IP address. When set to `true` SSH communicator will connect to this IP after boot.
 
-- `address` (string) - Address
+- `family` (string) - IP address family (IPv4 or IPv6)
+
+- `address` (string) - IP address. Note that at the moment using floating IPs is not supported.
 
 <!-- End of code generated from the comments of the IPAddress struct in builder/upcloud/config.go; -->

--- a/docs-partials/builder/upcloud/NetworkInterface-not-required.mdx
+++ b/docs-partials/builder/upcloud/NetworkInterface-not-required.mdx
@@ -1,9 +1,9 @@
 <!-- Code generated from the comments of the NetworkInterface struct in builder/upcloud/config.go; DO NOT EDIT MANUALLY -->
 
-- `ip_addresses` ([]IPAddress) - IP Addresses
+- `ip_addresses` ([]IPAddress) - List of IP Addresses
 
-- `type` (string) - Type
+- `type` (InterfaceType) - Network type (e.g. public, utility, private)
 
-- `network` (string) - Network
+- `network` (string) - Network UUID when connecting private network
 
 <!-- End of code generated from the comments of the NetworkInterface struct in builder/upcloud/config.go; -->

--- a/docs-partials/config/builder/upcloud/interfaces_ipv6.pkr.hcl
+++ b/docs-partials/config/builder/upcloud/interfaces_ipv6.pkr.hcl
@@ -29,33 +29,36 @@ variable "ssh_public_key" {
 source "upcloud" "test" {
   username        = "${var.username}"
   password        = "${var.password}"
-  zone            = "nl-ams1"
-  storage_name    = "ubuntu server 20.04"
-  template_prefix = "ubuntu-server"
-
+  zone            = "fi-hel1"
+  storage_name    = "Debian GNU/Linux 11 (Bullseye)"
+  template_prefix = "debian11"
   network_interfaces {
     ip_addresses {
-      family = "IPv4"
+      family = "IPv6"
     }
     type = "public"
   }
+  communicator = "ssh"
 
-  network_interfaces {
-    ip_addresses {
-      family = "IPv4"
-    }
-    type = "utility"
-  }
+  # Use bastion host if no IPv6 connection is available
+  # ssh_bastion_username         = "<bastion_username>"
+  # ssh_bastion_host             = "<bastion_host>"
+  # ssh_bastion_private_key_file = "<bastion_private_key_file>"
 }
 
 build {
   sources = ["source.upcloud.test"]
 
   provisioner "shell" {
+    environment_vars = [
+      "DEBIAN_FRONTEND=noninteractive",
+      "APT_LISTCHANGES_FRONTEND=none",
+    ]
+
     inline = [
       "apt-get update",
       "apt-get upgrade -y",
-      "echo '${file(var.ssh_public_key)}' | tee /root/.ssh/authorized_keys"
+      "echo '${file(var.ssh_public_key)}' | tee /root/.ssh/authorized_keys",
     ]
   }
 }

--- a/docs-partials/config/builder/upcloud/interfaces_private.pkr.hcl
+++ b/docs-partials/config/builder/upcloud/interfaces_private.pkr.hcl
@@ -29,33 +29,40 @@ variable "ssh_public_key" {
 source "upcloud" "test" {
   username        = "${var.username}"
   password        = "${var.password}"
-  zone            = "nl-ams1"
-  storage_name    = "ubuntu server 20.04"
-  template_prefix = "ubuntu-server"
+  zone            = "fi-hel1"
+  storage_name    = "Debian GNU/Linux 11 (Bullseye)"
+  template_prefix = "debian11"
 
   network_interfaces {
     ip_addresses {
-      family = "IPv4"
+      default = true
+      address = "10.0.0.20"
+      family  = "IPv4"
     }
-    type = "public"
+    network = "<network_uuid>"
+    type    = "private"
   }
+  communicator = "ssh"
 
-  network_interfaces {
-    ip_addresses {
-      family = "IPv4"
-    }
-    type = "utility"
-  }
+  # Use bastion host to get access to private network if need
+  # ssh_bastion_username         = "<bastion_username>"
+  # ssh_bastion_host             = "<bastion_host>"
+  # ssh_bastion_private_key_file = "<bastion_private_key_file>"
 }
 
 build {
   sources = ["source.upcloud.test"]
 
   provisioner "shell" {
+    environment_vars = [
+      "DEBIAN_FRONTEND=noninteractive",
+      "APT_LISTCHANGES_FRONTEND=none",
+    ]
+
     inline = [
       "apt-get update",
       "apt-get upgrade -y",
-      "echo '${file(var.ssh_public_key)}' | tee /root/.ssh/authorized_keys"
+      "echo '${file(var.ssh_public_key)}' | tee /root/.ssh/authorized_keys",
     ]
   }
 }

--- a/docs-src/builder/upcloud.mdx
+++ b/docs-src/builder/upcloud.mdx
@@ -58,7 +58,18 @@ Configuration reads your SSH public key from the default location `~/.ssh/id_rsa
 $ packer build -var="ssh_public_key=/some/other/path/id_rsa.pub"
 ```
 
+#### Network interfaces
 This template uses `network_interfaces` to define network interfaces to be used during the creation of the server for building the packer image.
 ```hcl
 @include 'config/builder/upcloud/interfaces.pkr.hcl'
+```
+
+#### IPv6 network interfaces
+```hcl
+@include 'config/builder/upcloud/interfaces_ipv6.pkr.hcl'
+```
+
+#### Private network interfaces
+```hcl
+@include 'config/builder/upcloud/interfaces_private.pkr.hcl'
 ```

--- a/docs/builder/upcloud.mdx
+++ b/docs/builder/upcloud.mdx
@@ -61,6 +61,8 @@ The upcloud builder is used to generate storage templates on UpCloud.
 
 - `state_timeout_duration` (duration string | ex: "1h5m2s") - The amount of time to wait for resource state changes. Defaults to `5m`.
 
+- `boot_wait` (duration string | ex: "1h5m2s") - The amount of time to wait after booting the server. Defaults to '0s'
+
 - `clone_zones` ([]string) - The array of extra zones (locations) where created templates should be cloned.
   Note that default `state_timeout_duration` is not enough for cloning, better to increase a value depending on storage size.
 
@@ -77,11 +79,11 @@ The upcloud builder is used to generate storage templates on UpCloud.
 
 <!-- Code generated from the comments of the NetworkInterface struct in builder/upcloud/config.go; DO NOT EDIT MANUALLY -->
 
-- `ip_addresses` ([]IPAddress) - IP Addresses
+- `ip_addresses` ([]IPAddress) - List of IP Addresses
 
-- `type` (string) - Type
+- `type` (InterfaceType) - Network type (e.g. public, utility, private)
 
-- `network` (string) - Network
+- `network` (string) - Network UUID when connecting private network
 
 <!-- End of code generated from the comments of the NetworkInterface struct in builder/upcloud/config.go; -->
 
@@ -90,9 +92,11 @@ The upcloud builder is used to generate storage templates on UpCloud.
 
 <!-- Code generated from the comments of the IPAddress struct in builder/upcloud/config.go; DO NOT EDIT MANUALLY -->
 
-- `family` (string) - Family
+- `default` (bool) - Default IP address. When set to `true` SSH communicator will connect to this IP after boot.
 
-- `address` (string) - Address
+- `family` (string) - IP address family (IPv4 or IPv6)
+
+- `address` (string) - IP address. Note that at the moment using floating IPs is not supported.
 
 <!-- End of code generated from the comments of the IPAddress struct in builder/upcloud/config.go; -->
 
@@ -164,6 +168,7 @@ Configuration reads your SSH public key from the default location `~/.ssh/id_rsa
 $ packer build -var="ssh_public_key=/some/other/path/id_rsa.pub"
 ```
 
+#### Network interfaces
 This template uses `network_interfaces` to define network interfaces to be used during the creation of the server for building the packer image.
 ```hcl
 packer {
@@ -210,15 +215,6 @@ source "upcloud" "test" {
 
   network_interfaces {
     ip_addresses {
-      address = "10.0.0.2"
-      family  = "IPv4"
-    }
-    network = "<network_uuid>"
-    type    = "private"
-  }
-
-  network_interfaces {
-    ip_addresses {
       family = "IPv4"
     }
     type = "utility"
@@ -233,6 +229,148 @@ build {
       "apt-get update",
       "apt-get upgrade -y",
       "echo '${file(var.ssh_public_key)}' | tee /root/.ssh/authorized_keys"
+    ]
+  }
+}
+
+```
+
+#### IPv6 network interfaces
+```hcl
+packer {
+  required_plugins {
+    upcloud = {
+      version = ">=v1.0.0"
+      source  = "github.com/UpCloudLtd/upcloud"
+    }
+  }
+}
+
+variable "username" {
+  type        = string
+  description = "UpCloud API username"
+  default     = "${env("UPCLOUD_API_USER")}"
+}
+
+variable "password" {
+  type        = string
+  description = "UpCloud API password"
+  default     = "${env("UPCLOUD_API_PASSWORD")}"
+  sensitive   = true
+}
+
+variable "ssh_public_key" {
+  type        = string
+  description = "Path to your SSH public key file"
+  default     = "~/.ssh/id_rsa.pub"
+}
+
+source "upcloud" "test" {
+  username        = "${var.username}"
+  password        = "${var.password}"
+  zone            = "fi-hel1"
+  storage_name    = "Debian GNU/Linux 11 (Bullseye)"
+  template_prefix = "debian11"
+  network_interfaces {
+    ip_addresses {
+      family = "IPv6"
+    }
+    type = "public"
+  }
+  communicator = "ssh"
+
+  # Use bastion host if no IPv6 connection is available
+  # ssh_bastion_username         = "<bastion_username>"
+  # ssh_bastion_host             = "<bastion_host>"
+  # ssh_bastion_private_key_file = "<bastion_private_key_file>"
+}
+
+build {
+  sources = ["source.upcloud.test"]
+
+  provisioner "shell" {
+    environment_vars = [
+      "DEBIAN_FRONTEND=noninteractive",
+      "APT_LISTCHANGES_FRONTEND=none",
+    ]
+
+    inline = [
+      "apt-get update",
+      "apt-get upgrade -y",
+      "echo '${file(var.ssh_public_key)}' | tee /root/.ssh/authorized_keys",
+    ]
+  }
+}
+
+```
+
+#### Private network interfaces
+```hcl
+packer {
+  required_plugins {
+    upcloud = {
+      version = ">=v1.0.0"
+      source  = "github.com/UpCloudLtd/upcloud"
+    }
+  }
+}
+
+variable "username" {
+  type        = string
+  description = "UpCloud API username"
+  default     = "${env("UPCLOUD_API_USER")}"
+}
+
+variable "password" {
+  type        = string
+  description = "UpCloud API password"
+  default     = "${env("UPCLOUD_API_PASSWORD")}"
+  sensitive   = true
+}
+
+variable "ssh_public_key" {
+  type        = string
+  description = "Path to your SSH public key file"
+  default     = "~/.ssh/id_rsa.pub"
+}
+
+source "upcloud" "test" {
+  username        = "${var.username}"
+  password        = "${var.password}"
+  zone            = "fi-hel1"
+  storage_name    = "Debian GNU/Linux 11 (Bullseye)"
+  template_prefix = "debian11"
+
+  network_interfaces {
+    ip_addresses {
+      default = true
+      address = "10.0.0.20"
+      family  = "IPv4"
+    }
+    network = "<network_uuid>"
+    type    = "private"
+  }
+  communicator = "ssh"
+
+  # Use bastion host to get access to private network if need
+  # ssh_bastion_username         = "<bastion_username>"
+  # ssh_bastion_host             = "<bastion_host>"
+  # ssh_bastion_private_key_file = "<bastion_private_key_file>"
+}
+
+build {
+  sources = ["source.upcloud.test"]
+
+  provisioner "shell" {
+    environment_vars = [
+      "DEBIAN_FRONTEND=noninteractive",
+      "APT_LISTCHANGES_FRONTEND=none",
+    ]
+
+    inline = [
+      "apt-get update",
+      "apt-get upgrade -y",
+      "echo '${file(var.ssh_public_key)}' | tee /root/.ssh/authorized_keys",
     ]
   }
 }


### PR DESCRIPTION
- drop public IPv4 requirement during build
- new `default` IP address flag to select used interface/IP during build
- new `wait_boot` flag adds ability to wait N time for server to boot up and start all services
- add `none` communicator support
- support IPv6 interfaces