### PR TITLE
fix(docs): exclude README.mdx from docs.zip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ examples/crash.log
 dist
 packer-plugin-upcloud
 vendor
+docs.zip

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ install-packer-sdc: ## Install packer sofware development command
 	go install github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc@$(HASHICORP_PACKER_PLUGIN_SDK_VERSION)
 
 ci-release-docs: install-packer-sdc generate
-	@/bin/sh -c "[ -d docs ] && zip -r docs.zip docs/"
+	@/bin/sh -c "[ -d docs ] && zip -x docs/README.mdx -r docs.zip docs/"
 
 plugin-check: install-packer-sdc build
 	$(PACKER_SDC) plugin-check $(BINARY)

--- a/docs-partials/config/builder/upcloud/interfaces_private.pkr.hcl
+++ b/docs-partials/config/builder/upcloud/interfaces_private.pkr.hcl
@@ -44,7 +44,7 @@ source "upcloud" "test" {
   }
   communicator = "ssh"
 
-  # Use bastion host to get access to private network if need
+  # Use bastion host to get access to private network
   # ssh_bastion_username         = "<bastion_username>"
   # ssh_bastion_host             = "<bastion_host>"
   # ssh_bastion_private_key_file = "<bastion_private_key_file>"

--- a/docs-src/README.mdx
+++ b/docs-src/README.mdx
@@ -43,7 +43,7 @@ on [installing a plugin](https://www.packer.io/docs/extending/plugins/#installin
 
 ### Builders
 
-- [upcloud](/docs/builder/upcloud.mdx) - The upcloud builder is used to generate storage templates on UpCloud.
+- [upcloud](/docs/builders/upcloud.mdx) - The upcloud builder is used to generate storage templates on UpCloud.
 
 ## JSON Templates
 From Packer version 1.7.0, template HCL2 becomes officially the preferred way to write Packer configuration. While the `json` format is still supported, but certain new features, such as `packer init` works only in newer HCL2 format.

--- a/docs-src/builders/upcloud.mdx
+++ b/docs-src/builders/upcloud.mdx
@@ -46,7 +46,7 @@ The upcloud builder is used to generate storage templates on UpCloud.
 -->
 ### Example Usage
 
-Here is a sample template, which you can also find in the [example](../../example/) directory.  
+Here is a sample template, which you can also find in the [example](https://github.com/UpCloudLtd/packer-plugin-upcloud/tree/master/example) directory.  
 It reads your UpCloud API credentials from the environment variables, creates an Ubuntu 20.04 LTS server in the `nl-ams1` region and authorizes root user to loggin with your public SSH key.
 
 ```hcl

--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -51,7 +51,7 @@ on [installing a plugin](https://www.packer.io/docs/extending/plugins/#installin
 
 ### Builders
 
-- [upcloud](/docs/builder/upcloud.mdx) - The upcloud builder is used to generate storage templates on UpCloud.
+- [upcloud](/docs/builders/upcloud.mdx) - The upcloud builder is used to generate storage templates on UpCloud.
 
 ## JSON Templates
 From Packer version 1.7.0, template HCL2 becomes officially the preferred way to write Packer configuration. While the `json` format is still supported, but certain new features, such as `packer init` works only in newer HCL2 format.

--- a/docs/builders/upcloud.mdx
+++ b/docs/builders/upcloud.mdx
@@ -109,7 +109,7 @@ The upcloud builder is used to generate storage templates on UpCloud.
 -->
 ### Example Usage
 
-Here is a sample template, which you can also find in the [example](../../example/) directory.  
+Here is a sample template, which you can also find in the [example](https://github.com/UpCloudLtd/packer-plugin-upcloud/tree/master/example) directory.  
 It reads your UpCloud API credentials from the environment variables, creates an Ubuntu 20.04 LTS server in the `nl-ams1` region and authorizes root user to loggin with your public SSH key.
 
 ```hcl

--- a/docs/builders/upcloud.mdx
+++ b/docs/builders/upcloud.mdx
@@ -352,7 +352,7 @@ source "upcloud" "test" {
   }
   communicator = "ssh"
 
-  # Use bastion host to get access to private network if need
+  # Use bastion host to get access to private network
   # ssh_bastion_username         = "<bastion_username>"
   # ssh_bastion_host             = "<bastion_host>"
   # ssh_bastion_private_key_file = "<bastion_private_key_file>"


### PR DESCRIPTION
### Changes
- exclude docs/README.mdx from docs.zip and rename docs/builder to docs/builders so that zip's content is compatible with Hashicorp website
- change example directory link to point GH repository

### Test docs.zip locally
- in `packer-plugin-upcloud` repository checkout `fix/docs-zip` branch
- run `make ci-release-docs` - this will create docs.zip in the project root dir
- clone Packer repository`git clone https://github.com/hashicorp/packer.git`
- copy `docs.zip` from UpCloud plugin repo into `website` folder
- append following JSON object to  `website/data/plugins-manifest.json`:
```
{
    "title": "UpCloud",
    "path": "upcloud",
    "repo": "hashicorp/packer-plugin-upcloud",
    "version": "latest",
    "sourceBranch": "master",
    "zipFile": "/website/docs.zip"
}
```
- start dev server using Docker  `cd website && make` (more info https://github.com/hashicorp/packer/tree/master/website#running-the-site-locally)
- open http://127.0.0.1:3000/plugins