### PR TITLE
feat(plugin): use common UpCloud env variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+- enviroment variables `UPCLOUD_USERNAME` and `UPCLOUD_PASSWORD` for authentication
+
+### Deprecated
+- environment variables `UPCLOUD_API_USER` and `UPCLOUD_API_PASSWORD`
+
 ## [1.4.0] - 2022-05-30
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -52,4 +52,9 @@ fmt:
 	packer fmt example/
 	packer fmt -recursive docs-partials/
 
+clean:
+	find . -name "packer_log_*" -delete
+	find . -name "TestBuilderAcc_*" -delete
+	find . -name "packer-plugin-upcloud" -delete
+
 .PHONY: default test test_integration lint build install

--- a/builder/upcloud/builder_acc_test.go
+++ b/builder/upcloud/builder_acc_test.go
@@ -146,11 +146,11 @@ func TestBuilderAcc_network_interfaces(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	if v := os.Getenv("UPCLOUD_API_USER"); v == "" {
-		t.Skip("UPCLOUD_API_USER must be set for acceptance tests")
+	if v := driver.UsernameFromEnv(); v == "" {
+		t.Skipf("%s or %s must be set for acceptance tests", driver.EnvConfigUsernameLegacy, driver.EnvConfigUsername)
 	}
-	if v := os.Getenv("UPCLOUD_API_PASSWORD"); v == "" {
-		t.Skip("UPCLOUD_API_PASSWORD must be set for acceptance tests")
+	if v := driver.PasswordFromEnv(); v == "" {
+		t.Skipf("%s or %s must be set for acceptance tests", driver.EnvConfigPasswordLegacy, driver.EnvConfigPassword)
 	}
 }
 
@@ -228,8 +228,8 @@ func teardown(testName string) func() error {
 		}
 
 		drv := driver.NewDriver(&driver.DriverConfig{
-			Username: os.Getenv("UPCLOUD_API_USER"),
-			Password: os.Getenv("UPCLOUD_API_PASSWORD"),
+			Username: driver.UsernameFromEnv(),
+			Password: driver.PasswordFromEnv(),
 			Timeout:  DefaultTimeout,
 		})
 

--- a/builder/upcloud/config.go
+++ b/builder/upcloud/config.go
@@ -4,9 +4,9 @@ package upcloud
 
 import (
 	"errors"
-	"os"
 	"time"
 
+	"github.com/UpCloudLtd/packer-plugin-upcloud/internal/driver"
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/v4/upcloud/request"
 	"github.com/hashicorp/packer-plugin-sdk/common"
@@ -227,13 +227,11 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 
 // get params from environment
 func (c *Config) setEnv() {
-	username := os.Getenv("UPCLOUD_API_USER")
-	if username != "" && c.Username == "" {
-		c.Username = username
+	if c.Username == "" {
+		c.Username = driver.UsernameFromEnv()
 	}
 
-	password := os.Getenv("UPCLOUD_API_PASSWORD")
-	if password != "" && c.Password == "" {
-		c.Password = password
+	if c.Password == "" {
+		c.Password = driver.PasswordFromEnv()
 	}
 }

--- a/docs-partials/config/builder/upcloud/interfaces.pkr.hcl
+++ b/docs-partials/config/builder/upcloud/interfaces.pkr.hcl
@@ -10,13 +10,13 @@ packer {
 variable "username" {
   type        = string
   description = "UpCloud API username"
-  default     = "${env("UPCLOUD_API_USER")}"
+  default     = "${env("UPCLOUD_USERNAME")}"
 }
 
 variable "password" {
   type        = string
   description = "UpCloud API password"
-  default     = "${env("UPCLOUD_API_PASSWORD")}"
+  default     = "${env("UPCLOUD_PASSWORD")}"
   sensitive   = true
 }
 

--- a/docs-partials/config/builder/upcloud/interfaces_ipv6.pkr.hcl
+++ b/docs-partials/config/builder/upcloud/interfaces_ipv6.pkr.hcl
@@ -10,13 +10,13 @@ packer {
 variable "username" {
   type        = string
   description = "UpCloud API username"
-  default     = "${env("UPCLOUD_API_USER")}"
+  default     = "${env("UPCLOUD_USERNAME")}"
 }
 
 variable "password" {
   type        = string
   description = "UpCloud API password"
-  default     = "${env("UPCLOUD_API_PASSWORD")}"
+  default     = "${env("UPCLOUD_PASSWORD")}"
   sensitive   = true
 }
 

--- a/docs-partials/config/builder/upcloud/interfaces_private.pkr.hcl
+++ b/docs-partials/config/builder/upcloud/interfaces_private.pkr.hcl
@@ -10,13 +10,13 @@ packer {
 variable "username" {
   type        = string
   description = "UpCloud API username"
-  default     = "${env("UPCLOUD_API_USER")}"
+  default     = "${env("UPCLOUD_USERNAME")}"
 }
 
 variable "password" {
   type        = string
   description = "UpCloud API password"
-  default     = "${env("UPCLOUD_API_PASSWORD")}"
+  default     = "${env("UPCLOUD_PASSWORD")}"
   sensitive   = true
 }
 

--- a/docs-src/post-processors/upcloud-import.mdx
+++ b/docs-src/post-processors/upcloud-import.mdx
@@ -14,7 +14,7 @@ Artifact BuilderId: `packer.post-processor.upcloud-import`
 The UpCloud importer can be used to import raw disk images as private templates to UpCloud.
 
 ### Required
-Username and password configuration arguments can be omitted if environment variables `UPCLOUD_API_USER` and `UPCLOUD_API_PASSWORD` are set.
+Username and password configuration arguments can be omitted if environment variables `UPCLOUD_USERNAME` and `UPCLOUD_PASSWORD` are set.
 
 @include 'post-processor/upcloud-import/Config-required.mdx'
 

--- a/docs/builders/upcloud.mdx
+++ b/docs/builders/upcloud.mdx
@@ -125,13 +125,13 @@ packer {
 variable "username" {
   type        = string
   description = "UpCloud API username"
-  default     = "${env("UPCLOUD_API_USER")}"
+  default     = "${env("UPCLOUD_USERNAME")}"
 }
 
 variable "password" {
   type        = string
   description = "UpCloud API password"
-  default     = "${env("UPCLOUD_API_PASSWORD")}"
+  default     = "${env("UPCLOUD_PASSWORD")}"
   sensitive   = true
 }
 
@@ -183,13 +183,13 @@ packer {
 variable "username" {
   type        = string
   description = "UpCloud API username"
-  default     = "${env("UPCLOUD_API_USER")}"
+  default     = "${env("UPCLOUD_USERNAME")}"
 }
 
 variable "password" {
   type        = string
   description = "UpCloud API password"
-  default     = "${env("UPCLOUD_API_PASSWORD")}"
+  default     = "${env("UPCLOUD_PASSWORD")}"
   sensitive   = true
 }
 
@@ -249,13 +249,13 @@ packer {
 variable "username" {
   type        = string
   description = "UpCloud API username"
-  default     = "${env("UPCLOUD_API_USER")}"
+  default     = "${env("UPCLOUD_USERNAME")}"
 }
 
 variable "password" {
   type        = string
   description = "UpCloud API password"
-  default     = "${env("UPCLOUD_API_PASSWORD")}"
+  default     = "${env("UPCLOUD_PASSWORD")}"
   sensitive   = true
 }
 
@@ -318,13 +318,13 @@ packer {
 variable "username" {
   type        = string
   description = "UpCloud API username"
-  default     = "${env("UPCLOUD_API_USER")}"
+  default     = "${env("UPCLOUD_USERNAME")}"
 }
 
 variable "password" {
   type        = string
   description = "UpCloud API password"
-  default     = "${env("UPCLOUD_API_PASSWORD")}"
+  default     = "${env("UPCLOUD_PASSWORD")}"
   sensitive   = true
 }
 

--- a/docs/post-processors/upcloud-import.mdx
+++ b/docs/post-processors/upcloud-import.mdx
@@ -14,7 +14,7 @@ Artifact BuilderId: `packer.post-processor.upcloud-import`
 The UpCloud importer can be used to import raw disk images as private templates to UpCloud.
 
 ### Required
-Username and password configuration arguments can be omitted if environment variables `UPCLOUD_API_USER` and `UPCLOUD_API_PASSWORD` are set.
+Username and password configuration arguments can be omitted if environment variables `UPCLOUD_USERNAME` and `UPCLOUD_PASSWORD` are set.
 
 <!-- Code generated from the comments of the Config struct in post-processor/upcloud-import/config.go; DO NOT EDIT MANUALLY -->
 
@@ -49,13 +49,13 @@ Import raw disk image from filesystem using `compress` post-processor to compres
 variable "username" {
   type        = string
   description = "UpCloud API username"
-  default     = env("UPCLOUD_API_USER")
+  default     = env("UPCLOUD_USERNAME")
 }
 
 variable "password" {
   type        = string
   description = "UpCloud API password"
-  default     = env("UPCLOUD_API_PASSWORD")
+  default     = env("UPCLOUD_PASSWORD")
   sensitive   = true
 }
 

--- a/example/build.pkr.hcl
+++ b/example/build.pkr.hcl
@@ -10,13 +10,13 @@ packer {
 variable "username" {
   type        = string
   description = "UpCloud API username"
-  default     = "${env("UPCLOUD_API_USER")}"
+  default     = "${env("UPCLOUD_USERNAME")}"
 }
 
 variable "password" {
   type        = string
   description = "UpCloud API password"
-  default     = "${env("UPCLOUD_API_PASSWORD")}"
+  default     = "${env("UPCLOUD_PASSWORD")}"
   sensitive   = true
 }
 

--- a/example/import.pkr.hcl
+++ b/example/import.pkr.hcl
@@ -1,13 +1,13 @@
 variable "username" {
   type        = string
   description = "UpCloud API username"
-  default     = env("UPCLOUD_API_USER")
+  default     = env("UPCLOUD_USERNAME")
 }
 
 variable "password" {
   type        = string
   description = "UpCloud API password"
-  default     = env("UPCLOUD_API_PASSWORD")
+  default     = env("UPCLOUD_PASSWORD")
   sensitive   = true
 }
 

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -3,6 +3,7 @@ package driver
 import (
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -13,8 +14,12 @@ import (
 )
 
 const (
-	DefaultPlan     = "1xCPU-2GB"
-	DefaultHostname = "custom"
+	DefaultPlan             string = "1xCPU-2GB"
+	DefaultHostname         string = "custom"
+	EnvConfigUsername       string = "UPCLOUD_USERNAME"
+	EnvConfigPassword       string = "UPCLOUD_PASSWORD"
+	EnvConfigUsernameLegacy string = "UPCLOUD_API_USER"
+	EnvConfigPasswordLegacy string = "UPCLOUD_API_PASSWORD"
 )
 
 type (
@@ -383,4 +388,20 @@ func (d *driver) GetAvailableZones() []string {
 
 func getNowString() string {
 	return time.Now().Format("20060102-150405")
+}
+
+func UsernameFromEnv() string {
+	username := os.Getenv(EnvConfigUsernameLegacy)
+	if username == "" {
+		username = os.Getenv(EnvConfigUsername)
+	}
+	return username
+}
+
+func PasswordFromEnv() string {
+	passwd := os.Getenv(EnvConfigPasswordLegacy)
+	if passwd == "" {
+		passwd = os.Getenv(EnvConfigPassword)
+	}
+	return passwd
 }

--- a/post-processor/upcloud-import/config.go
+++ b/post-processor/upcloud-import/config.go
@@ -4,9 +4,9 @@ package upcloudimport
 
 import (
 	"errors"
-	"os"
 	"time"
 
+	"github.com/UpCloudLtd/packer-plugin-upcloud/internal/driver"
 	"github.com/hashicorp/packer-plugin-sdk/common"
 	"github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/template/config"
@@ -94,9 +94,9 @@ func NewConfig(raws ...interface{}) (*Config, error) {
 
 func (c *Config) fromEnv() {
 	if c.Username == "" {
-		c.Username = os.Getenv("UPCLOUD_API_USER")
+		c.Username = driver.UsernameFromEnv()
 	}
 	if c.Password == "" {
-		c.Password = os.Getenv("UPCLOUD_API_PASSWORD")
+		c.Password = driver.PasswordFromEnv()
 	}
 }

--- a/post-processor/upcloud-import/post-processor_acc_test.go
+++ b/post-processor/upcloud-import/post-processor_acc_test.go
@@ -30,14 +30,14 @@ func TestPostProcessorAcc_raw(t *testing.T) {
 	if os.Getenv("PACKER_ACC") != "1" {
 		t.Skip("skip acceptance test")
 	}
-	username := os.Getenv("UPCLOUD_API_USER")
+	username := driver.UsernameFromEnv()
 	if username == "" {
-		t.Skip("UPCLOUD_API_USER must be set for acceptance tests")
+		t.Skipf("%s or %s must be set for acceptance tests", driver.EnvConfigUsernameLegacy, driver.EnvConfigUsername)
 	}
 
-	password := os.Getenv("UPCLOUD_API_PASSWORD")
+	password := driver.PasswordFromEnv()
 	if password == "" {
-		t.Skip("UPCLOUD_API_PASSWORD must be set for acceptance tests")
+		t.Skipf("%s or %s must be set for acceptance tests", driver.EnvConfigPasswordLegacy, driver.EnvConfigPassword)
 	}
 
 	testName := fmt.Sprintf("%s-acc-test-%s", BuilderID, time.Now().Format(timestampSuffixLayout))


### PR DESCRIPTION
Use environment variables `UPCLOUD_USERNAME` and `UPCLOUD_PASSWORD` for
authentication.

Variables `UPCLOUD_API_USER` and `UPCLOUD_API_PASSWORD` still work but
are considered to be deprecated.