### PR TITLE
fix(driver): disable client timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+- client timeout when importing large images
+
 ## [1.5.0] - 2022-06-09
 
 ### Added

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -65,6 +65,8 @@ type (
 
 func NewDriver(c *DriverConfig) Driver {
 	client := client.New(c.Username, c.Password)
+	// A Timeout of zero means no timeout.
+	client.SetTimeout(0)
 	svc := service.New(client)
 	return &driver{
 		svc:    svc,


### PR DESCRIPTION
Default client timeout might cause timeout when importing large images.