### PR TITLE
Add action for auto-generating the documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,28 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+      - test-docs-generator # for testing
+
+jobs:
+  update:
+    name: Update
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: "1.17"
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.head_ref }}
+    - name: Generate documentation
+      run: make generate
+    - name: Commit changes
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: "chore(docs): update documentation"
+        file_pattern: docs/


### PR DESCRIPTION
This repository has the same branch protection rules for `main` as our Terraform provider, see related work there https://github.com/UpCloudLtd/terraform-provider-upcloud/pull/287.