### PR TITLE
chore: run tests also after merge to main

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,9 @@
 name: test
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
This fixes the badge in README so that the test status is displayed accurately.

We could later decide on common practice across our repositories for testing main branch and displaying test status as a badge.