### PR TITLE
docs: mark plugin as hcp ready

### DIFF
--- a/.web-docs/metadata.hcl
+++ b/.web-docs/metadata.hcl
@@ -4,6 +4,7 @@ integration {
   name = "UpCloud"
   description = "A builder plugin for Packer which can be used to generate storage templates on UpCloud."
   identifier = "packer/UpCloudLtd/upcloud"
+  flags = ["hcp-ready"]
   component {
     type = "builder"
     name = "UpCloud"


### PR DESCRIPTION
Since the plugin supports HCP Packer, we should tag it as such.