### PR TITLE
Makefile: make dev uses packer for install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 BINARY=packer-plugin-upcloud
-HASHICORP_PACKER_PLUGIN_SDK_VERSION?=$(shell go list -m github.com/hashicorp/packer-plugin-sdk | cut -d " " -f2)
-COUNT?=1
+dev:
+	@go build -ldflags="-X '${PLUGIN_FQN}/version.VersionPrerelease=dev'" -o '${BINARY}'
+	packer plugins install --path ${BINARY} "$(shell echo "${PLUGIN_FQN}" | sed 's/packer-plugin-//')"
 TEST?=$(shell go list ./...)
 
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
When building the development version of the plugin, we now use
`packer plugins install` for that instead of moving it to the plugins
directory manually.

This target will require Packer 1.10.2 and above to function, as prior
versions don't support instaling pre-release versions of a plugin with
that command.
