### PR TITLE
feat: make storage tier configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- Enable storage tier customisation through `storage_tier` parameter
+
 ### Fixed
 
 - Update Go version to 1.24 and fix security vulnerabilities

--- a/builder/upcloud/builder_acc_test.go
+++ b/builder/upcloud/builder_acc_test.go
@@ -31,6 +31,9 @@ var testBuilderStorageName string
 //go:embed test-fixtures/json/networking.json
 var testBuilderNetworking string
 
+//go:embed test-fixtures/json/basic_standard_tier.json
+var testBuilderBasicStandardTier string
+
 func TestBuilderAcc_default(t *testing.T) {
 	testAccPreCheck(t)
 
@@ -59,6 +62,17 @@ func TestBuilderAcc_storageName(t *testing.T) {
 	testCase := &acctest.PluginTestCase{
 		Name:     t.Name(),
 		Template: testBuilderStorageName,
+		Check:    checkTestResult(),
+		Teardown: teardown(t.Name()),
+	}
+	acctest.TestPlugin(t, testCase)
+}
+
+func TestBuilderAcc_standardTier(t *testing.T) {
+	testAccPreCheck(t)
+	testCase := &acctest.PluginTestCase{
+		Name:     t.Name(),
+		Template: testBuilderBasicStandardTier,
 		Check:    checkTestResult(),
 		Teardown: teardown(t.Name()),
 	}

--- a/builder/upcloud/config.go
+++ b/builder/upcloud/config.go
@@ -24,6 +24,7 @@ const (
 	DefaultCommunicator                 = "ssh"
 	DefaultStorageSize                  = 25
 	DefaultTimeout                      = 5 * time.Minute
+	DefaultStorageTier                  = upcloud.StorageTierMaxIOPS
 	InterfaceTypePublic   InterfaceType = upcloud.IPAddressAccessPublic
 	InterfaceTypeUtility  InterfaceType = upcloud.IPAddressAccessUtility
 	InterfaceTypePrivate  InterfaceType = upcloud.IPAddressAccessPrivate
@@ -103,6 +104,10 @@ type Config struct {
 	// The operating system disk can also be later extended if needed. Note that Windows templates require large storage size, than default 25 Gb.
 	StorageSize int `mapstructure:"storage_size"`
 
+	// The storage tier to use. Available options are `maxiops`, `archive`, and `standard`. Defaults to `maxiops`.
+	// For most production workloads, MaxIOPS is recommended for best performance.
+	StorageTier string `mapstructure:"storage_tier"`
+
 	// The amount of time to wait for resource state changes. Defaults to `5m`.
 	Timeout time.Duration `mapstructure:"state_timeout_duration"`
 
@@ -156,6 +161,10 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 
 	if c.StorageSize == 0 {
 		c.StorageSize = DefaultStorageSize
+	}
+
+	if c.StorageTier == "" {
+		c.StorageTier = DefaultStorageTier
 	}
 
 	if c.Timeout == 0 {

--- a/builder/upcloud/config.hcl2spec.go
+++ b/builder/upcloud/config.hcl2spec.go
@@ -75,6 +75,7 @@ type FlatConfig struct {
 	TemplatePrefix            *string                `mapstructure:"template_prefix" cty:"template_prefix" hcl:"template_prefix"`
 	TemplateName              *string                `mapstructure:"template_name" cty:"template_name" hcl:"template_name"`
 	StorageSize               *int                   `mapstructure:"storage_size" cty:"storage_size" hcl:"storage_size"`
+	StorageTier               *string                `mapstructure:"storage_tier" cty:"storage_tier" hcl:"storage_tier"`
 	Timeout                   *string                `mapstructure:"state_timeout_duration" cty:"state_timeout_duration" hcl:"state_timeout_duration"`
 	BootWait                  *string                `mapstructure:"boot_wait" cty:"boot_wait" hcl:"boot_wait"`
 	CloneZones                []string               `mapstructure:"clone_zones" cty:"clone_zones" hcl:"clone_zones"`
@@ -160,6 +161,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"template_prefix":              &hcldec.AttrSpec{Name: "template_prefix", Type: cty.String, Required: false},
 		"template_name":                &hcldec.AttrSpec{Name: "template_name", Type: cty.String, Required: false},
 		"storage_size":                 &hcldec.AttrSpec{Name: "storage_size", Type: cty.Number, Required: false},
+		"storage_tier":                 &hcldec.AttrSpec{Name: "storage_tier", Type: cty.String, Required: false},
 		"state_timeout_duration":       &hcldec.AttrSpec{Name: "state_timeout_duration", Type: cty.String, Required: false},
 		"boot_wait":                    &hcldec.AttrSpec{Name: "boot_wait", Type: cty.String, Required: false},
 		"clone_zones":                  &hcldec.AttrSpec{Name: "clone_zones", Type: cty.List(cty.String), Required: false},

--- a/builder/upcloud/step_create_server.go
+++ b/builder/upcloud/step_create_server.go
@@ -48,6 +48,7 @@ func (s *StepCreateServer) Run(ctx context.Context, state multistep.StateBag) mu
 		Zone:         s.Config.Zone,
 		SshPublicKey: sshKeyPublic,
 		Networking:   networking,
+		StorageTier:  s.Config.StorageTier,
 	})
 	if err != nil {
 		return stepHaltWithError(state, err)

--- a/builder/upcloud/test-fixtures/hcl2/basic_standard_tier.hcl
+++ b/builder/upcloud/test-fixtures/hcl2/basic_standard_tier.hcl
@@ -1,0 +1,9 @@
+source "upcloud" "standard-tier" {
+  storage_uuid = "01000000-0000-4000-8000-000150020100" # Rocky Linux 9
+  zone         = "nl-ams1"
+  storage_tier = "standard"
+}
+
+build {
+  sources = ["source.upcloud.standard-tier"]
+} 

--- a/builder/upcloud/test-fixtures/json/basic_standard_tier.json
+++ b/builder/upcloud/test-fixtures/json/basic_standard_tier.json
@@ -1,0 +1,8 @@
+{
+    "builders": [{
+        "type": "upcloud",
+        "zone": "nl-ams1",
+        "storage_uuid": "01000000-0000-4000-8000-000150020100",
+        "storage_tier": "standard"
+    }]
+}

--- a/docs-partials/builder/upcloud/Config-not-required.mdx
+++ b/docs-partials/builder/upcloud/Config-not-required.mdx
@@ -16,6 +16,9 @@
   Changing this value is useful if you aim to build a template for larger server configurations where the preconfigured server disk is larger than 25 GB.
   The operating system disk can also be later extended if needed. Note that Windows templates require large storage size, than default 25 Gb.
 
+- `storage_tier` (string) - The storage tier to use. Available options are `maxiops`, `archive`, and `standard`. Defaults to `maxiops`.
+  For most production workloads, MaxIOPS is recommended for best performance.
+
 - `state_timeout_duration` (duration string | ex: "1h5m2s") - The amount of time to wait for resource state changes. Defaults to `5m`.
 
 - `boot_wait` (duration string | ex: "1h5m2s") - The amount of time to wait after booting the server. Defaults to '0s'

--- a/example/build.pkr.hcl
+++ b/example/build.pkr.hcl
@@ -32,6 +32,8 @@ source "upcloud" "test" {
   zone            = "nl-ams1"
   storage_name    = "ubuntu server 20.04"
   template_prefix = "ubuntu-server"
+  # uncomment to use standard tier storage
+  # storage_tier = "standard
 }
 
 build {

--- a/example/import.pkr.hcl
+++ b/example/import.pkr.hcl
@@ -35,6 +35,7 @@ build {
       username         = "${var.username}"
       password         = "${var.password}"
       zones            = ["pl-waw1", "fi-hel2"]
+      storage_tier     = "maxiops"
     }
   }
 }

--- a/post-processor/upcloud-import/config.go
+++ b/post-processor/upcloud-import/config.go
@@ -33,6 +33,9 @@ type Config struct {
 	// Replace existing template if one exists with the same name. Defaults to `false`.
 	ReplaceExisting bool `mapstructure:"replace_existing"`
 
+	// The storage tier to use. Available options are `maxiops`, `archive`, and `standard`. Defaults to `maxiops`.
+	StorageTier string `mapstructure:"storage_tier"`
+
 	// The amount of time to wait for resource state changes. Defaults to `60m`.
 	Timeout time.Duration `mapstructure:"state_timeout_duration"`
 
@@ -87,6 +90,11 @@ func NewConfig(raws ...interface{}) (*Config, error) {
 
 	if c.Timeout < 1 {
 		c.Timeout = defaultTimeout
+	}
+
+	// Set the default storage tier to maxiops if not specified
+	if c.StorageTier == "" {
+		c.StorageTier = "maxiops"
 	}
 
 	return &c, nil

--- a/post-processor/upcloud-import/step_create_storage.go
+++ b/post-processor/upcloud-import/step_create_storage.go
@@ -31,7 +31,10 @@ func (s *stepCreateStorage) Run(ctx context.Context, state multistep.StateBag) m
 	}
 	ui.Say(fmt.Sprintf("Creating storage device (%dGB) for '%s' image", size, s.image.File()))
 	storage, err := s.postProcessor.driver.CreateTemplateStorage(ctx,
-		fmt.Sprintf("%s-%s", BuilderID, time.Now().Format(timestampSuffixLayout)), s.postProcessor.config.Zones[0], size)
+		fmt.Sprintf("%s-%s", BuilderID, time.Now().Format(timestampSuffixLayout)),
+		s.postProcessor.config.Zones[0],
+		size,
+		s.postProcessor.config.StorageTier)
 
 	if err != nil {
 		return haltOnError(ui, state, err)


### PR DESCRIPTION
Users can now choose between `maxiops`, `standard` and `archive` storage  tiers in both builder and post-processor.

Requires #65 + fixes #61