### PR TITLE
chore: release 1.6.0

### DIFF
--- a/.web-docs/components/builder/upcloud/README.md
+++ b/.web-docs/components/builder/upcloud/README.md
@@ -50,6 +50,9 @@ The upcloud builder is used to generate storage templates on UpCloud.
   Changing this value is useful if you aim to build a template for larger server configurations where the preconfigured server disk is larger than 25 GB.
   The operating system disk can also be later extended if needed. Note that Windows templates require large storage size, than default 25 Gb.
 
+- `storage_tier` (string) - The storage tier to use. Available options are `maxiops`, `archive`, and `standard`. Defaults to `maxiops`.
+  For most production workloads, MaxIOPS is recommended for best performance.
+
 - `state_timeout_duration` (duration string | ex: "1h5m2s") - The amount of time to wait for resource state changes. Defaults to `5m`.
 
 - `boot_wait` (duration string | ex: "1h5m2s") - The amount of time to wait after booting the server. Defaults to '0s'
@@ -138,6 +141,8 @@ source "upcloud" "test" {
   zone            = "nl-ams1"
   storage_name    = "ubuntu server 20.04"
   template_prefix = "ubuntu-server"
+  # uncomment to use standard tier storage
+  # storage_tier = "standard
 }
 
 build {

--- a/.web-docs/components/post-processor/upcloud-import/README.md
+++ b/.web-docs/components/post-processor/upcloud-import/README.md
@@ -27,6 +27,8 @@ Username and password configuration arguments can be omitted if environment vari
 
 - `replace_existing` (bool) - Replace existing template if one exists with the same name. Defaults to `false`.
 
+- `storage_tier` (string) - The storage tier to use. Available options are `maxiops`, `archive`, and `standard`. Defaults to `maxiops`.
+
 - `state_timeout_duration` (duration string | ex: "1h5m2s") - The amount of time to wait for resource state changes. Defaults to `60m`.
 
 <!-- End of code generated from the comments of the Config struct in post-processor/upcloud-import/config.go; -->
@@ -74,6 +76,7 @@ build {
       username         = "${var.username}"
       password         = "${var.password}"
       zones            = ["pl-waw1", "fi-hel2"]
+      storage_tier     = "maxiops"
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [1.6.0] - 2025-05-23
+
 ### Added
 
 - Enable storage tier customisation through `storage_tier` parameter
@@ -100,7 +102,8 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 - Upgrade to Packer 1.7.0
 - Copy codebase from https://github.com/UpCloudLtd/upcloud-packer
 
-[Unreleased]: https://github.com/UpCloudLtd/packer-plugin-upcloud/compare/v1.5.3...HEAD
+[Unreleased]: https://github.com/UpCloudLtd/packer-plugin-upcloud/compare/v1.6.0...HEAD
+[1.6.0]: https://github.com/UpCloudLtd/packer-plugin-upcloud/compare/v1.5.3...v1.6.0
 [1.5.3]: https://github.com/UpCloudLtd/packer-plugin-upcloud/compare/v1.5.2...v1.5.3
 [1.5.2]: https://github.com/UpCloudLtd/packer-plugin-upcloud/compare/v1.5.1...v1.5.2
 [1.5.1]: https://github.com/UpCloudLtd/packer-plugin-upcloud/compare/v1.5.0...v1.5.1

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ This is a builder plugin for Packer which can be used to generate storage templa
 
 ## Documentation
 
-Documentation is available in [docs](docs/) directory.
+See [plugin documentation](https://developer.hashicorp.com/packer/integrations/UpCloudLtd/upcloud/).
 
-Check the [example](example/) directory for working example.
+Check also the [examples](example/).
 
 ## License
 

--- a/docs-partials/post-processor/upcloud-import/Config-not-required.mdx
+++ b/docs-partials/post-processor/upcloud-import/Config-not-required.mdx
@@ -2,6 +2,8 @@
 
 - `replace_existing` (bool) - Replace existing template if one exists with the same name. Defaults to `false`.
 
+- `storage_tier` (string) - The storage tier to use. Available options are `maxiops`, `archive`, and `standard`. Defaults to `maxiops`.
+
 - `state_timeout_duration` (duration string | ex: "1h5m2s") - The amount of time to wait for resource state changes. Defaults to `60m`.
 
 <!-- End of code generated from the comments of the Config struct in post-processor/upcloud-import/config.go; -->

--- a/post-processor/upcloud-import/config.hcl2spec.go
+++ b/post-processor/upcloud-import/config.hcl2spec.go
@@ -15,6 +15,7 @@ type FlatConfig struct {
 	Zones               []string          `mapstructure:"zones" required:"true" cty:"zones" hcl:"zones"`
 	TemplateName        *string           `mapstructure:"template_name" required:"true" cty:"template_name" hcl:"template_name"`
 	ReplaceExisting     *bool             `mapstructure:"replace_existing" cty:"replace_existing" hcl:"replace_existing"`
+	StorageTier         *string           `mapstructure:"storage_tier" cty:"storage_tier" hcl:"storage_tier"`
 	Timeout             *string           `mapstructure:"state_timeout_duration" cty:"state_timeout_duration" hcl:"state_timeout_duration"`
 	PackerBuildName     *string           `mapstructure:"packer_build_name" cty:"packer_build_name" hcl:"packer_build_name"`
 	PackerBuilderType   *string           `mapstructure:"packer_builder_type" cty:"packer_builder_type" hcl:"packer_builder_type"`
@@ -43,6 +44,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"zones":                      &hcldec.AttrSpec{Name: "zones", Type: cty.List(cty.String), Required: false},
 		"template_name":              &hcldec.AttrSpec{Name: "template_name", Type: cty.String, Required: false},
 		"replace_existing":           &hcldec.AttrSpec{Name: "replace_existing", Type: cty.Bool, Required: false},
+		"storage_tier":               &hcldec.AttrSpec{Name: "storage_tier", Type: cty.String, Required: false},
 		"state_timeout_duration":     &hcldec.AttrSpec{Name: "state_timeout_duration", Type: cty.String, Required: false},
 		"packer_build_name":          &hcldec.AttrSpec{Name: "packer_build_name", Type: cty.String, Required: false},
 		"packer_builder_type":        &hcldec.AttrSpec{Name: "packer_builder_type", Type: cty.String, Required: false},


### PR DESCRIPTION
Prepare release 1.6.0 with:

- Changelog entries
- Documentation update ("make docs")
- Missing storage tier parameter for postprocessor ("make generate")