### PR TITLE
chore: upgrade Go from 1.24.3 to 1.24.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 - Authentication token support through `UPCLOUD_TOKEN` environment variable and `token` config parameter
 
+### Fixed
+
+- Update Go version to 1.24.4
+
 ## [1.6.0] - 2025-05-23
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/UpCloudLtd/packer-plugin-upcloud
 
-go 1.24
+go 1.24.4
 
 require (
 	github.com/UpCloudLtd/upcloud-go-api/v8 v8.18.0


### PR DESCRIPTION
Includes multiple security related fixes.

Workflows will pick the Go version from `go.mod`.