### PR TITLE
chore: bump Go version to 1.24.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- Update Go version to 1.24.6
+
 ## [1.7.0] - 2025-06-10
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/UpCloudLtd/packer-plugin-upcloud
 
-go 1.24.4
+go 1.24.6
 
 require (
 	github.com/UpCloudLtd/upcloud-go-api/v8 v8.18.0


### PR DESCRIPTION
Includes security fixes and bug fixes to the runtime.