### PR TITLE
chore: bump test timeout for acceptance tests

### DIFF
--- a/builder/upcloud/builder_acc_test.go
+++ b/builder/upcloud/builder_acc_test.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/packer-plugin-sdk/acctest"
 
@@ -20,6 +21,8 @@ import (
 )
 
 // Run tests: PACKER_ACC=1 go test -count 1 -v ./...  -timeout=120m
+
+const defaultTestTimeout = 15 * time.Minute
 
 // json
 
@@ -261,7 +264,7 @@ func teardown(t *testing.T, testName string) func() error {
 		drv := driver.NewDriver(&driver.DriverConfig{
 			Username: driver.UsernameFromEnv(),
 			Password: driver.PasswordFromEnv(),
-			Timeout:  DefaultTimeout,
+			Timeout:  defaultTestTimeout,
 		})
 
 		for _, u := range uuids {


### PR DESCRIPTION
With heavy parallel tests the teardown function in acceptance tests will fail. This commit adds a custom timeout. Previously the tests were using a global default timeout settings, which was set to 5 minutes and it caused issues.