### PR TITLE
refactor: use `credentials` module to parse credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ See updating [Changelog example here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- Support for using API token from system keyring.
+
+### Changed
+
+- If both basic authentication and API token are provided, the API token will be used instead of raising an error.
+
 ## [1.8.1] - 2025-08-18
 
 ### Fixed

--- a/builder/upcloud/builder_acc_test.go
+++ b/builder/upcloud/builder_acc_test.go
@@ -177,11 +177,10 @@ func TestBuilderAcc_network_interfaces(t *testing.T) {
 
 func testAccPreCheck(t *testing.T) {
 	t.Helper()
-	if v := driver.UsernameFromEnv(); v == "" {
-		t.Skipf("%s or %s must be set for acceptance tests", driver.EnvConfigUsernameLegacy, driver.EnvConfigUsername)
-	}
-	if v := driver.PasswordFromEnv(); v == "" {
-		t.Skipf("%s or %s must be set for acceptance tests", driver.EnvConfigPasswordLegacy, driver.EnvConfigPassword)
+
+	_, err := driver.CredentialsFromEnv("", "", "")
+	if err != nil {
+		t.Skip(err.Error())
 	}
 }
 
@@ -261,9 +260,11 @@ func teardown(t *testing.T, testName string) func() error {
 			return err
 		}
 
+		creds, _ := driver.CredentialsFromEnv("", "", "")
 		drv := driver.NewDriver(&driver.DriverConfig{
-			Username: driver.UsernameFromEnv(),
-			Password: driver.PasswordFromEnv(),
+			Username: creds.Username,
+			Password: creds.Password,
+			Token:    creds.Token,
 			Timeout:  defaultTestTimeout,
 		})
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/UpCloudLtd/packer-plugin-upcloud
 go 1.25.0
 
 require (
+	github.com/UpCloudLtd/upcloud-go-api/credentials v0.1.1
 	github.com/UpCloudLtd/upcloud-go-api/v8 v8.25.0
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/hashicorp/packer-plugin-sdk v0.6.2
@@ -12,6 +13,7 @@ require (
 )
 
 require (
+	al.essio.dev/pkg/shellescape v1.5.1 // indirect
 	cloud.google.com/go v0.110.8 // indirect
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	cloud.google.com/go/iam v1.1.3 // indirect
@@ -26,10 +28,12 @@ require (
 	github.com/aws/aws-sdk-go v1.44.114 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
+	github.com/danieljoos/wincred v1.2.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dylanmei/iso8601 v0.1.0 // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
+	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/gofrs/uuid v4.1.0+incompatible // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
@@ -84,6 +88,7 @@ require (
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+	github.com/zalando/go-keyring v0.2.6 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29 // indirect
 	golang.org/x/mod v0.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+al.essio.dev/pkg/shellescape v1.5.1 h1:86HrALUujYS/h+GtqoB26SBEdkWfmMI6FubjXlsXyho=
+al.essio.dev/pkg/shellescape v1.5.1/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.110.8 h1:tyNdfIxjzaWctIiLYOTalaLKZ17SI44SKFW26QbOhME=
 cloud.google.com/go v0.110.8/go.mod h1:Iz8AkXJf1qmxC3Oxoep8R1T36w8B92yU29PcBhHO5fk=
@@ -17,6 +19,8 @@ github.com/ChrisTrenkamp/goxpath v0.0.0-20210404020558-97928f7e12b6/go.mod h1:nu
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/UpCloudLtd/upcloud-go-api/credentials v0.1.1 h1:eTfQsv58ufALOk9BZ7WbS/i7pMUD11RnYYpRPsz0LdI=
+github.com/UpCloudLtd/upcloud-go-api/credentials v0.1.1/go.mod h1:7OtVs2UqtfvjkC1HfE+Oud0MnbMv7qUWnbEgxnTAqts=
 github.com/UpCloudLtd/upcloud-go-api/v8 v8.25.0 h1:OWkIs5Z67jZJb9qNHNaNCl20vJaCIn9U1QnaRZE5grQ=
 github.com/UpCloudLtd/upcloud-go-api/v8 v8.25.0/go.mod h1:ImDdnWfVVM6WCRTrskGhAw2W1cRwu5IEkBw+9UCzAv8=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
@@ -55,6 +59,8 @@ github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6D
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/danieljoos/wincred v1.2.2 h1:774zMFJrqaeYCK2W57BgAem/MLi6mtSE47MB6BOJ0i0=
+github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7nd/ogr0Uh8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -83,6 +89,8 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
+github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=
 github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
@@ -124,6 +132,8 @@ github.com/google/martian/v3 v3.3.2 h1:IqNFLAmvJOgVlpdEBiQbDc2EwKW77amAycfTuWKdf
 github.com/google/martian/v3 v3.3.2/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
 github.com/google/s2a-go v0.1.7 h1:60BLSyTrOV4/haCDW4zb1guZItoSq8foHCXrAnjBo/o=
 github.com/google/s2a-go v0.1.7/go.mod h1:50CgR4k1jNlWBu4UfS4AcfhVe1r6pdZPygJ3R8F0Qdw=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
 github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -340,6 +350,8 @@ github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
+github.com/zalando/go-keyring v0.2.6 h1:r7Yc3+H+Ux0+M72zacZoItR3UDxeWfKTcabvkI8ua9s=
+github.com/zalando/go-keyring v0.2.6/go.mod h1:2TCrxYrbUNYfNS/Kgy/LSrkSQzZ5UPVH85RwfczwvcI=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/UpCloudLtd/upcloud-go-api/credentials"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/client"
 	"github.com/UpCloudLtd/upcloud-go-api/v8/upcloud/request"
@@ -450,22 +451,19 @@ func getNowString() string {
 	return time.Now().Format("20060102-150405")
 }
 
-func UsernameFromEnv() string {
-	username := os.Getenv(EnvConfigUsernameLegacy)
-	if username == "" {
-		username = os.Getenv(EnvConfigUsername)
+func CredentialsFromEnv(username, password, token string) (credentials.Credentials, error) {
+	config := credentials.Credentials{
+		Username: username,
+		Password: password,
+		Token:    token,
 	}
-	return username
-}
 
-func PasswordFromEnv() string {
-	passwd := os.Getenv(EnvConfigPasswordLegacy)
-	if passwd == "" {
-		passwd = os.Getenv(EnvConfigPassword)
+	if config.Username == "" {
+		config.Username = os.Getenv(EnvConfigUsernameLegacy)
 	}
-	return passwd
-}
+	if config.Password == "" {
+		config.Password = os.Getenv(EnvConfigPasswordLegacy)
+	}
 
-func TokenFromEnv() string {
-	return os.Getenv(EnvConfigAPIToken)
+	return credentials.Parse(config) //nolint:wrapcheck // Use the original error from shared credentials package
 }

--- a/post-processor/upcloud-import/config_test.go
+++ b/post-processor/upcloud-import/config_test.go
@@ -58,9 +58,10 @@ func TestNewConfig_BothAuthMethods(t *testing.T) {
 		"template_name": "my-template",
 	}}...)
 
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "you cannot specify both username/password and token")
-	require.NotNil(t, c)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-api-token", c.Token)
+	assert.Equal(t, "", c.Username)
+	assert.Equal(t, "", c.Password)
 }
 
 func TestNewConfig_NoAuthMethods(t *testing.T) {
@@ -70,8 +71,8 @@ func TestNewConfig_NoAuthMethods(t *testing.T) {
 		"template_name": "my-template",
 	}}...)
 
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "authentication required: specify either username and password, or token")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "credentials not found")
 	require.NotNil(t, c)
 }
 
@@ -83,8 +84,8 @@ func TestNewConfig_OnlyUsername(t *testing.T) {
 		"template_name": "my-template",
 	}}...)
 
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "'password' must be specified when using username/password authentication")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "credentials not found")
 	require.NotNil(t, c)
 }
 
@@ -96,8 +97,8 @@ func TestNewConfig_OnlyPassword(t *testing.T) {
 		"template_name": "my-template",
 	}}...)
 
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "'username' must be specified when using username/password authentication")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "credentials not found")
 	require.NotNil(t, c)
 }
 

--- a/post-processor/upcloud-import/post-processor_acc_test.go
+++ b/post-processor/upcloud-import/post-processor_acc_test.go
@@ -34,14 +34,9 @@ func TestPostProcessorAcc_raw(t *testing.T) {
 		t.Skip("skip acceptance test")
 	}
 	ctx := t.Context()
-	username := driver.UsernameFromEnv()
-	if username == "" {
-		t.Skipf("%s or %s must be set for acceptance tests", driver.EnvConfigUsernameLegacy, driver.EnvConfigUsername)
-	}
-
-	password := driver.PasswordFromEnv()
-	if password == "" {
-		t.Skipf("%s or %s must be set for acceptance tests", driver.EnvConfigPasswordLegacy, driver.EnvConfigPassword)
+	creds, err := driver.CredentialsFromEnv("", "", "")
+	if err != nil {
+		t.Skip(err.Error())
 	}
 
 	testName := fmt.Sprintf("%s-acc-test-%s", BuilderID, time.Now().Format(timestampSuffixLayout))
@@ -55,8 +50,9 @@ func TestPostProcessorAcc_raw(t *testing.T) {
 
 	var p PostProcessor
 	err = p.Configure([]interface{}{map[string]interface{}{
-		"username":         username,
-		"password":         password,
+		"username":         creds.Username,
+		"password":         creds.Password,
+		"token":            creds.Token,
 		"zones":            []string{"pl-waw1", "fi-hel2"},
 		"template_name":    testName,
 		"replace_existing": true,
@@ -72,8 +68,9 @@ func TestPostProcessorAcc_raw(t *testing.T) {
 	require.NotNil(t, a)
 
 	driver := driver.NewDriver(&driver.DriverConfig{
-		Username: username,
-		Password: password,
+		Username: creds.Username,
+		Password: creds.Password,
+		Token:    creds.Token,
 		Timeout:  time.Minute * 30,
 	})
 	t1, err := driver.GetTemplateByName(ctx, testName, "pl-waw1")


### PR DESCRIPTION
The shared credentials module adds support for using token saved to system keyring with `upctl account login --with-token`.